### PR TITLE
Add thin or thick border option

### DIFF
--- a/lithophane/data/layout.json
+++ b/lithophane/data/layout.json
@@ -48,6 +48,7 @@
                         {   "type":"range", "name": "maxOutputDimensionInMM", "title": "Maximum Size (MM)"  , "minVal":   1  , "maxVal": 1000, "step":  1  , "value": 100   },
                         {   "type":"range", "name": "actualThicknessInMM"   , "title": "Thickness (MM)"     , "minVal":   1  , "maxVal":   50, "step":  0.1, "value":   3   },
                         {   "type":"range", "name": "borderThicknessInMM"   , "title": "Border (MM)"        , "minVal":   0  , "maxVal":   50, "step":  0.1, "value":   0   },
+                        {   "type":"range", "name": "thinOrThickBorder"     , "title": "Thin border"        , "minVal":   0  , "maxVal":    1, "step":  1  , "value":   0   ,"onState": "Thick Border"},
                         {   "type":"range", "name": "minThicknessInMM"      , "title": "Thinnest Layer (MM)", "minVal":   0.1, "maxVal":  100, "step":  0.1, "value":   0.8 },
                         {   "type":"range", "name": "vertexPixelRatio"      , "title": "Vectors Per Pixel"  , "minVal":   1  , "maxVal":   10, "step":  1  , "value":   4   },
                         {   "type":"range", "name": "baseDepth"             , "title": "Base/Stand Depth"   , "minVal": -50  , "maxVal":   50, "step":  1  , "value":   0   },

--- a/lithophane/js/main.js
+++ b/lithophane/js/main.js
@@ -850,12 +850,17 @@ LITHO.ImageMap.prototype = {
         var repeatY=params.repeatY;
         var mirrorRep=params.mirrorRepeat===1;
         var flipRep=params.flipRepeat===1;
+        var thickBorder=params.thinOrThickBorder;
 
         // we'll need the 2D context to manipulate the data
         var canvas_context = outputCanvas.getContext("2d");
         canvas_context.beginPath();
         canvas_context.lineWidth = "1";
-        canvas_context.fillStyle = "black";
+        if (positive && !thickBorder || !positive && thickBorder) {
+            canvas_context.fillStyle = "black";
+        } else {
+            canvas_context.fillStyle = "white";
+        }
         canvas_context.rect(0, 0, outputCanvas.width, outputCanvas.height);
         canvas_context.fill();
         //fill the canvas black then place the image in the centre leaving black pixels to form the border


### PR DESCRIPTION
Adds an extra option in the model settings to set wether the outside border should be thin or thick. Before, this was determined by wether you chose a positive or negative image.